### PR TITLE
feat(cache): 提升 prompt 缓存命中率（稳定前缀 + 压缩缓存保持 + 覆盖率指标）

### DIFF
--- a/apps/electron/src/main/lib/adapters/pi-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/pi-agent-adapter.ts
@@ -35,19 +35,23 @@ import type {
   ThinkingConfig,
   TypedError,
   ModelMetadataOverride,
+  ModelCompatOverride,
   ProviderDbModel,
 } from '@kila/shared'
 import { extractKilaImageAttachments, inferApiTypeFromProvider, resolveModelMetadata, resolveThinkingLevel, detectBackgroundEvents, type ModelCapabilitiesOverride } from '@kila/shared'
 import { convertHistoryToPiMessages } from './pi-history-converter'
-import { deriveCompactionSettings, estimateCjkRatio, getCompactionNoopMessage, mapPiUsageToAgentEventUsage, parseManualCompactCommand, toPiCompactionSettings, waitForCompactionToSettle } from '../compaction-settings'
+import { deriveCompactionSettings, estimateCjkRatio, getCompactionNoopMessage, mapPiUsageToAgentEventUsage, parseManualCompactCommand, resolveEffectiveContextWindow, toPiCompactionSettings, waitForCompactionToSettle } from '../compaction-settings'
 import { getPiAgentDir, getPiSessionDir } from '../config-paths'
 import { resolveModelCost } from '../model-pricing'
-import { resolvePiModelContextWindow, resolvePiModelMaxTokens } from '../pi-model-catalog'
 import {
   createKilaModelRuntime,
   updateKilaModelRuntimeApiKey,
   type KilaModelRuntime,
 } from './pi-model-runtime'
+import {
+  createCacheAwareCompactionStreamFn,
+  type PromptCacheRetention,
+} from './pi-cache-aware-compaction'
 
 
 import { createLogger } from '../logger'
@@ -86,6 +90,11 @@ export interface PiAgentQueryOptions extends AgentQueryInput {
   modelMetadata?: ModelMetadataOverride
   /** 已按渠道 capabilityProviderId 解析的 Provider DB 模型能力画像。 */
   modelProviderDbEntry?: ProviderDbModel
+  /** OpenAI/Anthropic-compatible provider 的缓存与 session-affinity 行为覆盖。 */
+  modelCompat?: PiModel['compat'] & ModelCompatOverride
+  /** 稳定 runtime context snapshot；仅在变化或压缩后注入一次。 */
+  runtimeContext?: string
+  runtimeContextFingerprint?: string
 }
 
 const FRIENDLY_ERROR_MESSAGES: Array<{ pattern: RegExp; message: string }> = [
@@ -244,6 +253,49 @@ function prefersOpenAIResponses(modelId: string): boolean {
   )
 }
 
+/**
+ * Kila 会把模型注册到自己的 providerId，导致 Pi 仅凭 provider 名称无法再命中部分
+ * provider 规则。这里补齐已知网关的缓存相关 compat，并允许按模型显式覆盖；未知
+ * provider 继续交给 Pi 的 URL 自动探测，避免首个请求加载整个 provider catalog。
+ */
+async function resolvePiModelCompat(
+  channel: PiQueryChannel,
+  modelId: string,
+  api: Api,
+  override?: PiModel['compat'],
+): Promise<PiModel['compat'] | undefined> {
+  const provider = `${channel.capabilityProviderId ?? ''} ${channel.provider} ${channel.baseUrl}`.toLowerCase()
+  // `PiModel['compat']` is a discriminated union keyed by API.  Compat
+  // inference below is intentionally runtime-selected, so collect the
+  // provider hints in a structural record and narrow at the boundary.
+  const inherited: Record<string, unknown> = {}
+
+  if (api === 'openai-completions' && (provider.includes('openrouter') || channel.baseUrl.includes('openrouter.ai'))) {
+    inherited.thinkingFormat = 'openrouter'
+    inherited.supportsDeveloperRole = false
+    inherited.sessionAffinityFormat = 'openrouter'
+    inherited.sendSessionAffinityHeaders = true
+    if (/^(~)?anthropic\//i.test(modelId)) inherited.cacheControlFormat = 'anthropic'
+  }
+
+  if (provider.includes('cloudflare') || channel.baseUrl.includes('gateway.ai.cloudflare.com')) {
+    inherited.sendSessionAffinityHeaders = true
+    inherited.supportsLongCacheRetention = false
+  }
+
+  if (provider.includes('fireworks') || channel.baseUrl.includes('fireworks.ai')) {
+    inherited.sendSessionAffinityHeaders = true
+  }
+
+  if (api === 'openai-completions' && (provider.includes('deepseek') || channel.baseUrl.includes('deepseek.com'))) {
+    inherited.thinkingFormat = 'deepseek'
+    inherited.requiresReasoningContentOnAssistantMessages = true
+  }
+
+  if (Object.keys(inherited).length === 0 && !override) return undefined
+  return { ...inherited, ...(override ?? {}) } as PiModel['compat']
+}
+
 export function resolvePiModelMetadata(
   channel: PiQueryChannel,
   modelId: string,
@@ -269,8 +321,11 @@ export async function buildPiModel(
   capabilitiesOverride?: ModelCapabilitiesOverride,
   hasImages?: boolean,
   providerDbEntry?: ProviderDbModel,
+  compatOverride?: PiModel['compat'],
 ): Promise<PiModel> {
   const provider = getPiProviderId(channel, modelId)
+  const api = resolvePiApiType(channel, modelId)
+  const compat = await resolvePiModelCompat(channel, modelId, api, compatOverride)
   const metadata = resolvePiModelMetadata(
     channel,
     modelId,
@@ -284,21 +339,27 @@ export async function buildPiModel(
   // 如果 API 真不支持图片，会在 adapter 层捕获错误并给出清晰提示。
   const includeImage = metadata.abilities.vision === 'supported' || (hasImages ?? false)
 
-  // context window / maxTokens 以 Pi SDK catalog + 模型名推断为准；手动覆盖优先，未知回 200K。
-  const contextWindow = await resolvePiModelContextWindow(channel, modelId, metadataOverride?.contextWindowTokens)
-  const maxTokens = await resolvePiModelMaxTokens(channel, modelId, metadataOverride?.maxOutputTokens)
+  // 窗口未知时保守兜底（32K），避免小窗口模型/私有聚合商按 200K 预算压缩时直接撞 overflow；
+  // 已知模型仍走 resolveModelMetadata 的统一窗口（manual > builtin/provider-rule > inference）。
+  const contextWindow = resolveEffectiveContextWindow(metadata)
+  if (contextWindow.source === 'fallback') {
+    log.warn(`[Pi Agent] 模型 ${modelId} 上下文窗口未知，按保守默认 ${contextWindow.contextWindowTokens} token 处理`)
+  }
+
+  const maxTokens = metadata.maxOutputTokens ?? 32768
 
   return {
     id: modelId,
     name: modelId,
-    api: resolvePiApiType(channel, modelId),
+    api,
     provider,
     baseUrl: channel.baseUrl,
     reasoning: metadata.abilities.reasoning === 'supported',
     input: includeImage ? ['text', 'image'] : ['text'],
     cost,
-    contextWindow,
+    contextWindow: contextWindow.contextWindowTokens,
     maxTokens,
+    ...(compat ? { compat } : {}),
   }
 }
 
@@ -833,14 +894,83 @@ interface PiRuntime {
   modelRuntime: KilaModelRuntime
   beforeToolCallRef: MutableRef<PiAgentQueryOptions['beforeToolCall'] | undefined>
   getAgentStateRef: MutableRef<(() => PiAgentState) | undefined>
+  runtimeContextFingerprint?: string
+  runtimeContextNeedsRefresh: boolean
+}
+
+function canonicalizeRuntimeValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map((item) => canonicalizeRuntimeValue(item))
+  if (!value || typeof value !== 'object') return value
+  const input = value as Record<string, unknown>
+  const output: Record<string, unknown> = {}
+  for (const key of Object.keys(input).sort()) {
+    output[key] = canonicalizeRuntimeValue(input[key])
+  }
+  return output
 }
 
 function safeStableStringify(value: unknown): string {
   try {
-    return JSON.stringify(value)
+    return JSON.stringify(canonicalizeRuntimeValue(value))
   } catch {
     return '[unserializable]'
   }
+}
+
+const RUNTIME_CONTEXT_MARKER = 'kila_runtime_context_snapshot'
+
+function textFromPiContent(content: unknown): string {
+  if (typeof content === 'string') return content
+  if (!Array.isArray(content)) return ''
+  return content
+    .filter((part): part is { type: 'text'; text: string } => (
+      Boolean(part)
+      && typeof part === 'object'
+      && (part as { type?: unknown }).type === 'text'
+      && typeof (part as { text?: unknown }).text === 'string'
+    ))
+    .map((part) => part.text)
+    .join('')
+}
+
+function findPersistedRuntimeContextFingerprint(sessionManager: SessionManager): string | undefined {
+  // 只从当前 compaction-aware context 查找；getEntries() 还包含已被压缩移除的旧消息，
+  // 若从那里恢复 marker 会错误地跳过下一轮 snapshot 注入。
+  const messages = sessionManager.buildSessionContext().messages
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index]
+    if (!message || !('content' in message)) continue
+    const content = (message as { content?: unknown }).content
+    const text = textFromPiContent(content)
+    const markerIndex = text.indexOf(`<${RUNTIME_CONTEXT_MARKER}`)
+    if (markerIndex < 0) continue
+    const marker = text.slice(markerIndex).match(
+      new RegExp(`<${RUNTIME_CONTEXT_MARKER}\\s+fingerprint="([^"]+)"`),
+    )
+    if (marker?.[1]) return marker[1]
+  }
+  return undefined
+}
+
+function formatRuntimeContextPrompt(snapshot: string, fingerprint: string): string {
+  return `<${RUNTIME_CONTEXT_MARKER} fingerprint="${fingerprint}">\n${snapshot}\n</${RUNTIME_CONTEXT_MARKER}>`
+}
+
+function materializeRuntimeContextPrompt(
+  runtime: PiRuntime,
+  options: PiAgentQueryOptions,
+): string {
+  const snapshot = options.runtimeContext?.trim()
+  const fingerprint = options.runtimeContextFingerprint?.trim()
+  if (!snapshot || !fingerprint) return options.prompt
+
+  const shouldInject = runtime.runtimeContextNeedsRefresh
+    || runtime.runtimeContextFingerprint !== fingerprint
+  if (!shouldInject) return options.prompt
+
+  runtime.runtimeContextFingerprint = fingerprint
+  runtime.runtimeContextNeedsRefresh = false
+  return `${formatRuntimeContextPrompt(snapshot, fingerprint)}\n\n${options.prompt}`
 }
 
 function createRuntimeSignature(options: PiAgentQueryOptions, model: PiModel): string {
@@ -872,7 +1002,13 @@ function createRuntimeSignature(options: PiAgentQueryOptions, model: PiModel): s
     thinkingLevel: resolvePiThinkingLevel(options.thinkingLevel, options.thinking, options.effort),
     systemPrompt: options.systemPrompt,
     tools: toolSignature,
+    compat: model.compat,
+    promptCacheRetention: options.modelCompat?.promptCacheRetention ?? 'short',
   })
+}
+
+function resolvePromptCacheRetention(options: PiAgentQueryOptions): PromptCacheRetention {
+  return options.modelCompat?.promptCacheRetention === 'long' ? 'long' : 'short'
 }
 
 function wrapToolsWithKilaPermission(
@@ -945,6 +1081,7 @@ export class PiAgentAdapter implements AgentProviderAdapter {
     const agentDir = getPiAgentDir()
     const sessionManager = sdk.SessionManager.continueRecent(cwd, getPiSessionDir(options.sessionId))
     const isNewPiSession = !hasPiSessionMessages(sessionManager)
+    const persistedRuntimeContextFingerprint = findPersistedRuntimeContextFingerprint(sessionManager)
     if (isNewPiSession) {
       sessionManager.newSession({ id: options.sessionId })
     }
@@ -1039,6 +1176,17 @@ export class PiAgentAdapter implements AgentProviderAdapter {
       customTools: wrappedTools,
     })
     session.agent.toolExecution = 'sequential'
+    const initialLlmMessages = await session.agent.convertToLlm(session.agent.state.messages)
+    session.agent.streamFunction = createCacheAwareCompactionStreamFn({
+      streamFn: session.agent.streamFunction,
+      sessionId: options.sessionId,
+      cacheRetention: resolvePromptCacheRetention(options),
+      initialContext: {
+        systemPrompt: session.agent.state.systemPrompt,
+        messages: initialLlmMessages,
+        tools: session.agent.state.tools,
+      },
+    })
     getAgentStateRef.current = () => session.agent.state
     session.setAutoCompactionEnabled(derivedCompaction.enabled)
 
@@ -1048,6 +1196,8 @@ export class PiAgentAdapter implements AgentProviderAdapter {
       modelRuntime,
       beforeToolCallRef,
       getAgentStateRef,
+      runtimeContextFingerprint: persistedRuntimeContextFingerprint,
+      runtimeContextNeedsRefresh: isNewPiSession || !persistedRuntimeContextFingerprint,
     }
   }
 
@@ -1095,6 +1245,7 @@ export class PiAgentAdapter implements AgentProviderAdapter {
       options.modelCapabilities,
       hasImages,
       options.modelProviderDbEntry,
+      options.modelCompat,
     )
     const queue: AgentEvent[] = []
     let done = false
@@ -1113,6 +1264,10 @@ export class PiAgentAdapter implements AgentProviderAdapter {
     }
 
     const unsubscribe = runtime.session.subscribe((event) => {
+      if (event.type === 'compaction_end' && event.result) {
+        // 压缩会重写请求历史，旧 snapshot 可能已被摘要覆盖；下一轮必须重建。
+        runtime.runtimeContextNeedsRefresh = true
+      }
       queue.push(...mapRuntimeEvent(event))
       wake()
     })
@@ -1154,7 +1309,7 @@ export class PiAgentAdapter implements AgentProviderAdapter {
       // Pi 0.80.x 会在 AgentSession 内处理 provider retry 与 context overflow：
       // agent_end → retry/compact → continue → agent_settled。这里绝不能重复提交 prompt。
       if (options.abortSignal?.aborted) return
-      await runtime.session.prompt(options.prompt, {
+      await runtime.session.prompt(materializeRuntimeContextPrompt(runtime, options), {
         images: options.promptImages,
         expandPromptTemplates: false,
       })

--- a/apps/electron/src/main/lib/adapters/pi-cache-aware-compaction.test.ts
+++ b/apps/electron/src/main/lib/adapters/pi-cache-aware-compaction.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from 'bun:test'
+import type { Context, Message } from '@earendil-works/pi-ai'
+import { serializeConversation } from '@earendil-works/pi-coding-agent'
+import { projectCacheAwareCompactionContext } from './pi-cache-aware-compaction'
+
+function user(text: string, timestamp: number): Message {
+  return {
+    role: 'user',
+    content: [{ type: 'text', text }],
+    timestamp,
+  }
+}
+
+function standaloneSummaryContext(messages: Message[], instruction = 'Summarize only.'): Context {
+  return {
+    systemPrompt: 'Pi standalone summarizer (must be replaced)',
+    messages: [user(
+      `<conversation>\n${serializeConversation(messages)}\n</conversation>\n\n${instruction}`,
+      99,
+    )],
+  }
+}
+
+describe('cache-aware Pi compaction projection', () => {
+  test('replays system, tools and all messages through the selected region before appending only the instruction', () => {
+    const checkpoint = user('prior compacted checkpoint', 1)
+    const selected = user('new history selected by Pi', 2)
+    const retained = user('recent suffix retained by Pi', 3)
+    const lastRoutedContext: Context = {
+      systemPrompt: 'stable Kila system prompt',
+      messages: [checkpoint, selected, retained],
+      tools: [{
+        name: 'stable_tool',
+        description: 'stable schema',
+        parameters: {
+          type: 'object',
+          properties: { value: { type: 'string' } },
+          required: ['value'],
+        } as never,
+      }],
+    }
+
+    // Pi's second compaction only serializes the newly selected entry.  Kila
+    // must still replay the prior checkpoint first because it was the first
+    // message in the actual warm provider request.
+    const projected = projectCacheAwareCompactionContext(
+      standaloneSummaryContext([selected], 'Produce the checkpoint.'),
+      lastRoutedContext,
+    )
+
+    expect(projected?.systemPrompt).toBe(lastRoutedContext.systemPrompt)
+    expect(projected?.tools).toBe(lastRoutedContext.tools)
+    expect(projected?.messages.slice(0, -1)).toEqual([checkpoint, selected])
+    expect(projected?.messages.at(-1)).toMatchObject({
+      role: 'user',
+      content: [{ type: 'text', text: expect.stringContaining('Produce the checkpoint.') }],
+    })
+    expect(JSON.stringify(projected)).not.toContain('<conversation>')
+    expect(projected?.messages).not.toContain(retained)
+  })
+
+  test('fails closed when Pi serialized content cannot be matched to the last routed request', () => {
+    const projected = projectCacheAwareCompactionContext(
+      standaloneSummaryContext([user('not present', 10)]),
+      {
+        systemPrompt: 'stable',
+        messages: [user('actual request', 1)],
+      },
+    )
+    expect(projected).toBeUndefined()
+  })
+
+  test('does not mistake an ordinary one-message prompt for a summarization request', () => {
+    const projected = projectCacheAwareCompactionContext(
+      { messages: [user('ordinary prompt', 2)] },
+      { messages: [user('ordinary prompt', 2)] },
+    )
+    expect(projected).toBeUndefined()
+  })
+})

--- a/apps/electron/src/main/lib/adapters/pi-cache-aware-compaction.ts
+++ b/apps/electron/src/main/lib/adapters/pi-cache-aware-compaction.ts
@@ -1,0 +1,251 @@
+/**
+ * Cache-aware Pi compaction request projection.
+ *
+ * Pi 0.82 serializes the selected conversation into one new user message and
+ * deliberately sends the summarization request with `cacheRetention: "none"`
+ * and a random session id.  Both choices make a long, otherwise warm session a
+ * cold request.
+ *
+ * Kila keeps Pi's compaction selection, persistence and lifecycle, but replaces
+ * the request envelope at the stream seam.  The last routed system prompt,
+ * tools and selected message prefix are replayed verbatim; only Pi's existing
+ * summarization instruction is appended as a new final user message.  This is
+ * the same prefix-preserving shape used by deepseek-harness.
+ */
+
+import type { StreamFn } from '@earendil-works/pi-agent-core'
+import type {
+  CacheRetention,
+  Context,
+  Message,
+} from '@earendil-works/pi-ai'
+
+export type PromptCacheRetention = Exclude<CacheRetention, 'none'>
+
+interface ParsedSummarizationPrompt {
+  conversation: string
+  instruction: string
+  message: Extract<Message, { role: 'user' }>
+}
+
+// `@earendil-works/pi-coding-agent` is ESM-only.  This file runs in the
+// CommonJS Electron main bundle, so a static import would become a top-level
+// `require()` and crash before the external ESM loader can run.  Keep the
+// small, stable serializer used by Pi's compaction protocol local instead.
+// It mirrors `packages/coding-agent/src/core/compaction/utils.ts` from the
+// pinned Pi 0.82.1 dependency.
+const TOOL_RESULT_MAX_CHARS = 2000
+
+function serializationContentText(content: unknown, separator = '\n'): string {
+  if (typeof content === 'string') return content
+  if (!Array.isArray(content)) return ''
+  return content
+    .filter((block): block is { type: 'text', text: string } => (
+      !!block
+      && typeof block === 'object'
+      && (block as { type?: unknown }).type === 'text'
+      && typeof (block as { text?: unknown }).text === 'string'
+    ))
+    .map((block) => block.text)
+    .join(separator)
+}
+
+function truncateForSerialization(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text
+  const truncatedChars = text.length - maxChars
+  return `${text.slice(0, maxChars)}\n\n[... ${truncatedChars} more characters truncated]`
+}
+
+function serializeConversation(messages: readonly Message[]): string {
+  const parts: string[] = []
+
+  for (const message of messages) {
+    const msg = message as Message & { content?: unknown }
+    if (msg.role === 'user') {
+      const content = serializationContentText(msg.content, '')
+      if (content) parts.push(`[User]: ${content}`)
+      continue
+    }
+
+    if (msg.role === 'assistant') {
+      const thinkingParts: string[] = []
+      const toolCalls: string[] = []
+      const content = Array.isArray(msg.content) ? msg.content : []
+      for (const block of content) {
+        if (!block || typeof block !== 'object') continue
+        const typedBlock = block as {
+          type?: unknown
+          thinking?: unknown
+          name?: unknown
+          arguments?: Record<string, unknown>
+        }
+        if (typedBlock.type === 'thinking' && typeof typedBlock.thinking === 'string') {
+          thinkingParts.push(typedBlock.thinking)
+        } else if (typedBlock.type === 'toolCall' && typedBlock.arguments) {
+          const argsStr = Object.entries(typedBlock.arguments)
+            .map(([key, value]) => `${key}=${JSON.stringify(value)}`)
+            .join(', ')
+          toolCalls.push(`${String(typedBlock.name ?? '')}(${argsStr})`)
+        }
+      }
+      if (thinkingParts.length > 0) {
+        parts.push(`[Assistant thinking]: ${thinkingParts.join('\n')}`)
+      }
+      if (content.some((block) => (
+        !!block && typeof block === 'object' && (block as { type?: unknown }).type === 'text'
+      ))) {
+        parts.push(`[Assistant]: ${serializationContentText(msg.content)}`)
+      }
+      if (toolCalls.length > 0) {
+        parts.push(`[Assistant tool calls]: ${toolCalls.join('; ')}`)
+      }
+      continue
+    }
+
+    if (msg.role === 'toolResult') {
+      const content = serializationContentText(msg.content, '')
+      if (content) parts.push(`[Tool result]: ${truncateForSerialization(content, TOOL_RESULT_MAX_CHARS)}`)
+    }
+  }
+
+  return parts.join('\n\n')
+}
+
+export interface CacheAwareStreamOptions {
+  streamFn: StreamFn
+  sessionId: string
+  cacheRetention: PromptCacheRetention
+  /**
+   * Initial active context for a restored session.  It is a correctness
+   * fallback for manual compaction before the first request in this process;
+   * the first real routed request replaces it.
+   */
+  initialContext?: Context
+}
+
+const CONVERSATION_OPEN = '<conversation>\n'
+const CONVERSATION_CLOSE = '\n</conversation>\n\n'
+
+// Pi's standalone SUMMARIZATION_SYSTEM_PROMPT is intentionally not replayed:
+// the original Kila system prompt must remain the cached prefix.  Keep the
+// equivalent safety boundary in the novel trailing instruction instead.
+const CACHE_AWARE_COMPACTION_GUARD = [
+  'Act only as the context compaction engine for this coding assistant.',
+  'Do not continue the conversation, answer the user, call tools, or take any action.',
+  'Output only the structured checkpoint requested below.',
+].join(' ')
+
+function textContent(message: Message): string {
+  if (message.role !== 'user') return ''
+  if (typeof message.content === 'string') return message.content
+  return message.content
+    .map((part) => part.type === 'text' ? part.text : '')
+    .join('')
+}
+
+/** Recognize Pi's generated summarization call without relying on its private system-prompt constant. */
+function parseSummarizationPrompt(context: Context): ParsedSummarizationPrompt | undefined {
+  if (context.messages.length !== 1) return undefined
+  const message = context.messages[0]
+  if (!message || message.role !== 'user') return undefined
+
+  const text = textContent(message)
+  if (!text.startsWith(CONVERSATION_OPEN)) return undefined
+  const closeIndex = text.indexOf(CONVERSATION_CLOSE, CONVERSATION_OPEN.length)
+  if (closeIndex < 0) return undefined
+
+  const conversation = text.slice(CONVERSATION_OPEN.length, closeIndex)
+  const instruction = text.slice(closeIndex + CONVERSATION_CLOSE.length).trim()
+  if (!conversation || !instruction) return undefined
+  return { conversation, instruction, message }
+}
+
+interface SerializedFragment {
+  text: string
+  messageIndex: number
+}
+
+/**
+ * Find the selected Pi compaction region inside the last provider request and
+ * return the last message index of that region.  Pi's serializer is applied to
+ * each message independently and joins non-empty fragments with two newlines,
+ * so this comparison stays byte-for-byte aligned with Pi without parsing its
+ * human-readable serialization.
+ */
+function findSelectedRegionEnd(messages: readonly Message[], serializedRegion: string): number | undefined {
+  const fragments: SerializedFragment[] = []
+  for (let messageIndex = 0; messageIndex < messages.length; messageIndex += 1) {
+    const message = messages[messageIndex]
+    if (!message) continue
+    const text = serializeConversation([message])
+    if (text) fragments.push({ text, messageIndex })
+  }
+
+  for (let start = 0; start < fragments.length; start += 1) {
+    if (!serializedRegion.startsWith(fragments[start]!.text)) continue
+    let candidate = ''
+    for (let end = start; end < fragments.length; end += 1) {
+      candidate += `${end === start ? '' : '\n\n'}${fragments[end]!.text}`
+      if (candidate === serializedRegion) return fragments[end]!.messageIndex
+      if (candidate.length >= serializedRegion.length || !serializedRegion.startsWith(candidate)) break
+    }
+  }
+  return undefined
+}
+
+/**
+ * Project a Pi standalone summarization request into a prefix-preserving one.
+ * Exported for focused regression tests and provider-payload diagnostics.
+ */
+export function projectCacheAwareCompactionContext(
+  summarizationContext: Context,
+  lastRoutedContext: Context,
+): Context | undefined {
+  const parsed = parseSummarizationPrompt(summarizationContext)
+  if (!parsed) return undefined
+
+  const selectedRegionEnd = findSelectedRegionEnd(
+    lastRoutedContext.messages,
+    parsed.conversation,
+  )
+  if (selectedRegionEnd === undefined) return undefined
+
+  const instructionMessage: Message = {
+    ...parsed.message,
+    content: [{ type: 'text', text: `${CACHE_AWARE_COMPACTION_GUARD}\n\n${parsed.instruction}` }],
+  }
+  return {
+    systemPrompt: lastRoutedContext.systemPrompt,
+    messages: [
+      ...lastRoutedContext.messages.slice(0, selectedRegionEnd + 1),
+      instructionMessage,
+    ],
+    ...(lastRoutedContext.tools ? { tools: lastRoutedContext.tools } : {}),
+  }
+}
+
+/**
+ * Wrap the Pi SDK stream function at its single provider boundary.
+ *
+ * Normal calls establish the warm-prefix reference.  Pi summarization calls
+ * are detected structurally, projected when possible, and always inherit the
+ * stable Kila session id plus the configured non-`none` cache retention.
+ */
+export function createCacheAwareCompactionStreamFn(options: CacheAwareStreamOptions): StreamFn {
+  let lastRoutedContext = options.initialContext
+
+  return async (model, context, requestOptions) => {
+    const projected = lastRoutedContext
+      ? projectCacheAwareCompactionContext(context, lastRoutedContext)
+      : undefined
+    const isSummarization = parseSummarizationPrompt(context) !== undefined
+
+    if (!isSummarization) lastRoutedContext = context
+
+    return options.streamFn(model, projected ?? context, {
+      ...requestOptions,
+      cacheRetention: options.cacheRetention,
+      sessionId: options.sessionId,
+    })
+  }
+}

--- a/apps/electron/src/main/lib/agent-memory-prompt.test.ts
+++ b/apps/electron/src/main/lib/agent-memory-prompt.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { composeAgentPrompt } from './memory/prompt-compose'
-import { buildSystemPromptAppend } from './agent-prompt-builder'
+import { buildDynamicContextProjection, buildSystemPromptAppend } from './agent-prompt-builder'
 
 describe('Agent memory prompt assembly', () => {
   test('Given 已构建的记忆 XML，When 组装最终 prompt，Then 注入正文而不是对象字符串', () => {
@@ -20,5 +20,24 @@ describe('Agent memory prompt assembly', () => {
 
     expect(prompt).toContain('nmem status')
     expect(prompt).toContain('不要使用 `browse-now status`')
+    expect(prompt).not.toContain('memory-prompt-test')
+  })
+
+  test('runtime snapshot keeps stable state out of system prompt and exposes a stable fingerprint', async () => {
+    const first = await buildDynamicContextProjection({
+      sessionId: 'runtime-projection-test',
+      projectName: 'Kila',
+      agentCwd: 'C:/workspace/kila',
+    })
+    const second = await buildDynamicContextProjection({
+      sessionId: 'runtime-projection-test',
+      projectName: 'Kila',
+      agentCwd: 'C:/workspace/kila',
+    })
+
+    expect(first.runtimeSnapshot).toContain('runtime-projection-test')
+    expect(first.runtimeSnapshot).toEqual(second.runtimeSnapshot)
+    expect(first.runtimeSnapshotFingerprint).toBe(second.runtimeSnapshotFingerprint)
+    expect(first.perMessageContext).toContain('系统时间')
   })
 })

--- a/apps/electron/src/main/lib/agent-orchestrator-context.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator-context.ts
@@ -7,7 +7,7 @@
 import { randomUUID } from 'node:crypto'
 import { homedir } from 'node:os'
 import type { AgentSendInput, KilaPermissionMode, MemoryRunTrace, PermissionRequest, AskUserRequest } from '@kila/shared'
-import { buildSessionContextSnapshot, inferContextWindow, resolveModelMetadata, resolveThinkingLevel } from '@kila/shared'
+import { buildSessionContextSnapshot, resolveModelMetadata, resolveThinkingLevel } from '@kila/shared'
 import type { PiAgentQueryOptions } from './adapters/pi-agent-adapter'
 import { buildPromptImages, splitAttachmentsForPiPrompt } from './adapters/pi-history-converter'
 import type { AgentEventBus } from './agent-event-bus'
@@ -16,13 +16,14 @@ import { resolveGlobalSkillMentionEntry } from './global-agent-config-manager'
 import { resolveShell } from './shell-resolver'
 import { buildShellPromptSection } from './shell-resolution'
 import { getSettings } from './settings-service'
-import { buildDynamicContext, buildSystemPromptAppend } from './agent-prompt-builder'
+import { buildDynamicContextProjection, buildSystemPromptAppend } from './agent-prompt-builder'
 import { permissionService, type PermissionResolution } from './agent-permission-service'
 import { askUserService } from './agent-ask-user-service'
 import { appendAgentMessage, getAgentMessages } from './agent-message-store'
 import { getBuiltinAgentTools, getMcpAgentTools } from './pi-tools-bridge'
 import {
   collectReservedToolNames,
+  canonicalizeAgentTools,
   mergeAgentTools,
   normalizeToolNameKey,
   type AnyAgentTool,
@@ -283,7 +284,7 @@ export async function buildAgentRunContext(
     providerDbEntry,
   })
 
-  const dynamicCtx = await buildDynamicContext({
+  const dynamicProjection = await buildDynamicContextProjection({
     sessionId,
     projectName,
     agentCwd,
@@ -341,7 +342,13 @@ export async function buildAgentRunContext(
     incognito: input.incognito,
   })
 
-  const finalPrompt = composeAgentPrompt(dynamicCtx, memoryContext.text, enrichedMessage)
+  // 稳定 runtime context 由 Pi adapter 作为一次性 snapshot 注入；每轮 prompt 只保留
+  // 时钟等易变信息，避免把 MCP/Skills/工作目录重复发送并破坏 append-only 前缀。
+  const finalPrompt = composeAgentPrompt(
+    dynamicProjection.perMessageContext,
+    memoryContext.text,
+    enrichedMessage,
+  )
 
   const thinkingLevel = resolveThinkingLevel({
     thinkingLevel: inputThinkingLevel ?? appSettings.agentThinkingLevel,
@@ -423,19 +430,18 @@ export async function buildAgentRunContext(
   )
 
   // 合并顺序即优先级：先到者保留，内置工具永远排在 MCP 与外部注入工具之前
-  const tools = mergeAgentTools([
+  const tools = canonicalizeAgentTools(mergeAgentTools([
     { source: 'Pi 内置编码工具', tools: codingTools },
     { source: 'Kila 内置工具', tools: builtinTools },
     { source: 'MCP 工具', tools: mcpToolBundle.tools },
     { source: '运行时注入工具', tools: extraTools },
-  ])
+  ]))
   const contextSnapshot = buildSessionContextSnapshot({
     modelId: resolvedModel,
-    // 预发快照与运行时 buildPiModel 保持同源：走模型名推断，不依赖 Provider DB / 内置目录。
-    contextWindow: inferContextWindow(resolvedModel),
+    contextWindow: modelMetadata.contextWindowTokens,
     historyTurns,
     systemPrompt: systemPromptText,
-    dynamicContext: dynamicCtx,
+    dynamicContext: dynamicProjection.fullContext,
     historyMessages,
     currentTurnText: finalPrompt,
     toolDefinitions: tools.map((tool) => ({
@@ -475,6 +481,8 @@ export async function buildAgentRunContext(
     queryOptions: {
       sessionId,
       prompt: finalPrompt,
+      runtimeContext: dynamicProjection.runtimeSnapshot,
+      runtimeContextFingerprint: dynamicProjection.runtimeSnapshotFingerprint,
       rawPrompt: userMessage,
       model: resolvedModel,
       cwd: agentCwd,
@@ -490,6 +498,7 @@ export async function buildAgentRunContext(
       modelCapabilities: resolvedChannelModel?.capabilities,
       modelMetadata: resolvedChannelModel?.metadataOverride,
       modelProviderDbEntry: providerDbEntry,
+      modelCompat: resolvedChannelModel?.compat,
     },
   }
 }

--- a/apps/electron/src/main/lib/agent-prompt-builder.ts
+++ b/apps/electron/src/main/lib/agent-prompt-builder.ts
@@ -5,7 +5,8 @@
  *
  * 设计策略（参考 Craft Agent OSS）：
  * - 静态 system prompt（buildSystemPromptAppend）：保持稳定以提升缓存命中率
- * - 动态 per-message 上下文（buildDynamicContext）：注入到用户消息前，每次实时读取磁盘
+ * - 动态 runtime snapshot：只在首次运行、内容变化或压缩后注入一次
+ * - 易变 per-message 上下文（buildDynamicContext）：只保留时钟信息，避免重复发送稳定配置
  */
 
 import type { KilaPermissionMode } from '@kila/shared'
@@ -26,6 +27,7 @@ interface SystemPromptContext {
   projectName?: string
   projectPath?: string
   projectProfileId?: string
+  /** 仅为兼容旧调用方保留；会话 ID 不再进入 system prompt。 */
   sessionId: string
   permissionMode: KilaPermissionMode
   /** 会话级覆盖的 prompt ID（优先于全局 activePromptId） */
@@ -155,7 +157,6 @@ Kila 的长期记忆完全由本机 Nowledge 管理。未配置 Nowledge 时记�
 - 全局 Agent 配置: ${configDir}/global-agent/
 - 全局 MCP 配置: ${configDir}/global-agent/mcp.json
 - 全局 Skills 目录: ${configDir}/global-agent/.agents/skills/
-- 当前会话 ID: ${ctx.sessionId}
 
 ### MCP 配置格式
 mcp.json 的顶层 key 必须是 \`servers\`（不是 mcpServers），示例：
@@ -245,6 +246,24 @@ interface DynamicContext {
   agentCwd?: string
 }
 
+/**
+ * 可缓存的 runtime context 投影。
+ *
+ * DeepSeek Harness 将运行时事实作为独立 snapshot 放入消息历史，而不是每轮重建
+ * system prompt。这里保持同样的边界：`perMessageContext` 只含时钟，稳定配置放在
+ * `runtimeSnapshot`，由 Pi adapter 在需要时注入一次。
+ */
+export interface DynamicContextProjection {
+  /** 每轮都允许更新的最小上下文（当前时间/时区）。 */
+  perMessageContext: string
+  /** 稳定 runtime snapshot（包含 session ID，但不污染 system prompt）。 */
+  runtimeSnapshot: string
+  /** 用于判断 snapshot 是否发生变化的稳定指纹。 */
+  runtimeSnapshotFingerprint: string
+  /** 兼容诊断/上下文估算的完整文本。 */
+  fullContext: string
+}
+
 function formatContextTime(now: Date, timeZone: string): string {
   return now.toLocaleString('zh-CN', {
     weekday: 'long',
@@ -258,41 +277,46 @@ function formatContextTime(now: Date, timeZone: string): string {
   })
 }
 
-/**
- * 构建每条消息的动态上下文
- *
- * 包含当前时间、工作区实时状态（MCP 服务器 + Skills）和工作目录。
- * 每次调用都从磁盘实时读取，确保配置变更后下一条消息即可感知。
- */
-export async function buildDynamicContext(ctx: DynamicContext): Promise<string> {
-  const sections: string[] = []
+function hashContext(text: string): string {
+  // FNV-1a：无需引入 crypto，且在不同平台上对同一 UTF-16 文本稳定。
+  let hash = 2166136261
+  for (let index = 0; index < text.length; index += 1) {
+    hash ^= text.charCodeAt(index)
+    hash = Math.imul(hash, 16777619)
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0')
+}
 
-  // 当前时间
+async function buildDynamicContextProjectionInternal(ctx: DynamicContext): Promise<DynamicContextProjection> {
+  const stableSections: string[] = []
   const now = new Date()
   const userProfile = getUserProfile()
   const systemTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
   const userTimeZone = userProfile.timeZone || systemTimeZone
 
-  sections.push(`**系统时间: ${formatContextTime(now, systemTimeZone)}**`)
-
-  const userContextLines = [
-    `- 用户称呼: ${userProfile.userName}`,
+  const perMessageLines = [
+    `**系统时间: ${formatContextTime(now, systemTimeZone)}**`,
+    `<user_clock_context>`,
     `- 用户本地时间: ${formatContextTime(now, userTimeZone)}`,
     `- 用户时区: ${userTimeZone}`,
     '- 解释“明天”“下周”“今晚”等相对时间时，优先使用这个时区',
+    '</user_clock_context>',
   ]
 
+  const userContextLines = [
+    `- 用户称呼: ${userProfile.userName}`,
+    `- 用户时区: ${userTimeZone}`,
+  ]
   const locationParts = [userProfile.city, userProfile.country].filter(Boolean)
   if (locationParts.length > 0) {
     userContextLines.push(`- 用户位置: ${locationParts.join(' / ')}`)
   }
-
-  sections.push(`<user_context>\n${userContextLines.join('\n')}\n</user_context>`)
+  stableSections.push(`<user_context>\n${userContextLines.join('\n')}\n</user_context>`)
 
   if (ctx.sessionId) {
     const scheduledTaskContext = getScheduledTaskRunContext(ctx.sessionId)
     if (scheduledTaskContext) {
-      sections.push(`<scheduled_task_context>
+      stableSections.push(`<scheduled_task_context>
 你当前正在执行一个后台定时任务。
 
 - 任务 ID: ${scheduledTaskContext.taskId}
@@ -304,16 +328,12 @@ export async function buildDynamicContext(ctx: DynamicContext): Promise<string> 
     }
   }
 
-  // 项目实时状态
   const projectLines: string[] = []
+  if (ctx.projectName) projectLines.push(`项目: ${ctx.projectName}`)
 
-  if (ctx.projectName) {
-    projectLines.push(`项目: ${ctx.projectName}`)
-  }
-
-  // MCP 服务器列表
   const mcpConfig = getGlobalAgentMcpConfig()
   const serverEntries = Object.entries(mcpConfig.servers ?? {})
+    .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)
   if (serverEntries.length > 0) {
     projectLines.push('全局 MCP 服务器:')
     for (const [name, entry] of serverEntries) {
@@ -325,8 +345,9 @@ export async function buildDynamicContext(ctx: DynamicContext): Promise<string> 
     }
   }
 
-  // Skills 列表（Pi 会自动发现，使用前先读取对应 SKILL.md）
-  const skills = getGlobalAgentSkills()
+  const skills = [...getGlobalAgentSkills()].sort((left, right) => (
+    left.slug < right.slug ? -1 : left.slug > right.slug ? 1 : 0
+  ))
   if (skills.length > 0) {
     const skillsRoot = getGlobalAgentSkillsDir()
     projectLines.push('全局 Skills（匹配时请先用 read 工具读取对应 SKILL.md，再按其中流程执行）:')
@@ -336,8 +357,6 @@ export async function buildDynamicContext(ctx: DynamicContext): Promise<string> 
     }
   }
 
-
-  // Cua Driver 桌面操控状态
   try {
     if (await isCuaDriverEnabled()) {
       projectLines.push('桌面操控 (Cua Driver): 已启用')
@@ -355,14 +374,37 @@ export async function buildDynamicContext(ctx: DynamicContext): Promise<string> 
   } catch {
     // 检测失败时静默跳过
   }
-  if (projectLines.length > 0) {
-    sections.push(`<project_state>\n${projectLines.join('\n')}\n</project_state>`)
-  }
+  if (projectLines.length > 0) stableSections.push(`<project_state>\n${projectLines.join('\n')}\n</project_state>`)
+  if (ctx.agentCwd) stableSections.push(`<working_directory>${ctx.agentCwd}</working_directory>`)
 
-  // 工作目录
-  if (ctx.agentCwd) {
-    sections.push(`<working_directory>${ctx.agentCwd}</working_directory>`)
-  }
+  // session ID 只出现在一次性 runtime snapshot，不再改变 system prompt 的缓存前缀。
+  if (ctx.sessionId) stableSections.unshift(`<session_context>\n- 会话 ID: ${ctx.sessionId}\n</session_context>`)
 
-  return sections.join('\n\n')
+  const runtimeSnapshotBody = stableSections.join('\n\n')
+  const runtimeSnapshot = runtimeSnapshotBody
+    ? `Current runtime context snapshot (apply only to this session):\n${runtimeSnapshotBody}`
+    : ''
+  const perMessageContext = perMessageLines.join('\n')
+
+  return {
+    perMessageContext,
+    runtimeSnapshot,
+    runtimeSnapshotFingerprint: hashContext(runtimeSnapshotBody),
+    fullContext: [perMessageContext, runtimeSnapshot].filter(Boolean).join('\n\n'),
+  }
+}
+
+/** 构建可缓存/易变分离的动态上下文。 */
+export async function buildDynamicContextProjection(ctx: DynamicContext): Promise<DynamicContextProjection> {
+  return buildDynamicContextProjectionInternal(ctx)
+}
+
+/**
+ * 构建每条消息的动态上下文
+ *
+ * 返回兼容旧调用方的完整文本；新调用方应使用 buildDynamicContextProjection，
+ * 将稳定工作区状态作为 snapshot，仅在变化或压缩后注入。
+ */
+export async function buildDynamicContext(ctx: DynamicContext): Promise<string> {
+  return (await buildDynamicContextProjectionInternal(ctx)).fullContext
 }

--- a/apps/electron/src/main/lib/agent-tool-names.test.ts
+++ b/apps/electron/src/main/lib/agent-tool-names.test.ts
@@ -9,6 +9,7 @@
 import { describe, expect, test } from 'bun:test'
 import {
   collectReservedToolNames,
+  canonicalizeAgentTools,
   ensureUniqueToolName,
   mergeAgentTools,
   normalizeToolNameKey,
@@ -161,5 +162,35 @@ describe('mergeAgentTools 冲突策略', () => {
     ])
 
     expect(merged.map((tool) => tool.name)).toEqual(['read'])
+  })
+})
+
+describe('canonicalizeAgentTools 缓存前缀稳定性', () => {
+  test('工具按 code-unit 名称排序且 schema object key 顺序稳定', () => {
+    const first = createTool('z_tool', 'z')
+    first.parameters = {
+      required: ['b', 'a'],
+      properties: { z: { type: 'string' }, a: { type: 'string' } },
+      type: 'object',
+    } as never
+    const second = createTool('a_tool', 'a')
+    second.parameters = {
+      type: 'object',
+      properties: { a: { type: 'string' }, z: { type: 'string' } },
+      required: ['b', 'a'],
+    } as never
+
+    const canonical = canonicalizeAgentTools([first, second])
+    expect(canonical.map((tool) => tool.name)).toEqual(['a_tool', 'z_tool'])
+    expect(JSON.stringify(canonical[0]?.parameters)).toBe(JSON.stringify({
+      properties: { a: { type: 'string' }, z: { type: 'string' } },
+      required: ['b', 'a'],
+      type: 'object',
+    }))
+    expect(JSON.stringify(canonical[1]?.parameters)).toBe(JSON.stringify({
+      properties: { a: { type: 'string' }, z: { type: 'string' } },
+      required: ['b', 'a'],
+      type: 'object',
+    }))
   })
 })

--- a/apps/electron/src/main/lib/agent-tool-names.ts
+++ b/apps/electron/src/main/lib/agent-tool-names.ts
@@ -26,6 +26,37 @@ const log = createLogger('Agent 工具名')
 // biome-ignore lint/suspicious/noExplicitAny: Pi 把 execute 声明为属性且 Static<TParameters> 在 strictFunctionTypes 下逆变，AgentTool<TObject> / AgentTool<unknown> 都无法容纳异构工具数组；这里是全仓唯一收口点
 export type AnyAgentTool = AgentTool<any>
 
+/**
+ * 规范化工具定义，使同一组工具在不同启动/文件系统顺序下产生字节一致的请求前缀。
+ *
+ * 只排序对象 key，不排序 schema 数组（required/enum/anyOf 的顺序可能具有语义），
+ * 因此不会改变工具行为；返回新对象也避免破坏 MCP/内置工具持有的原始 schema。
+ */
+function canonicalizeJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map((item) => canonicalizeJson(item))
+  if (!value || typeof value !== 'object') return value
+
+  const input = value as Record<string, unknown>
+  const output: Record<string, unknown> = {}
+  for (const key of Object.keys(input).sort()) {
+    output[key] = canonicalizeJson(input[key])
+  }
+  return output
+}
+
+export function canonicalizeAgentTools(tools: AnyAgentTool[]): AnyAgentTool[] {
+  return [...tools]
+    .sort((left, right) => {
+      if (left.name < right.name) return -1
+      if (left.name > right.name) return 1
+      return 0
+    })
+    .map((tool) => ({
+      ...tool,
+      parameters: canonicalizeJson(tool.parameters) as never,
+    }))
+}
+
 /** 工具名归一化：冲突判定必须大小写不敏感，否则 `Read` 会绕过 `read` 的占位 */
 export function normalizeToolNameKey(name: string): string {
   return name.trim().toLowerCase()

--- a/apps/electron/src/main/lib/channel-manager.ts
+++ b/apps/electron/src/main/lib/channel-manager.ts
@@ -83,10 +83,9 @@ function migrateChannelModel(model: ChannelModel): { model: ChannelModel; change
   }
 
   const metadataOverride = normalizeModelMetadataOverride(model.metadataOverride, model.capabilities)
+  const { capabilities: _legacyCapabilities, ...modelWithoutLegacyCapabilities } = model
   const migrated: ChannelModel = {
-    id: model.id,
-    name: model.name,
-    enabled: model.enabled,
+    ...modelWithoutLegacyCapabilities,
     ...(metadataOverride ? { metadataOverride } : {}),
   }
 

--- a/apps/electron/src/main/lib/compaction-settings.ts
+++ b/apps/electron/src/main/lib/compaction-settings.ts
@@ -18,19 +18,42 @@
  */
 
 import type { Usage } from '@earendil-works/pi-ai'
-import type { AgentEventUsage } from '@kila/shared'
+import type { AgentEventUsage, ResolvedModelMetadata } from '@kila/shared'
 
 // ============================================================================
 // 上下文窗口
 // ============================================================================
 
 /**
- * 模型窗口非法（非正数）时的兜底值，供 deriveCompactionSettings 的 invalid-window 递归兜底使用。
+ * 模型窗口未知时的保守兜底值。
  *
- * 注意：正常的「未知模型」窗口已由 shared 层 `inferContextWindow` 统一给 200K（单一数据源），
- * 这里不再承担「未知模型默认窗口」职责，只在窗口数值非法时兜底。
+ * 旧实现兜底 200000：本地模型、私有网关、小众聚合商都认不出模型名，于是 8K 的本地模型
+ * 被告知「你有 20 万窗口」，该压的时候不压，直接撞 context overflow。
+ * 方向必须反过来 —— 宁可多压一次，也不能整轮请求被 provider 拒绝。
  */
 export const FALLBACK_CONTEXT_WINDOW_TOKENS = 32768
+
+/** 有效上下文窗口及其来源；`fallback` 表示模型窗口未知，用的是保守默认值。 */
+export interface EffectiveContextWindow {
+  contextWindowTokens: number
+  source: 'known' | 'fallback'
+}
+
+/**
+ * 从已解析的模型元数据取出可用于压缩/预算计算的有效窗口。
+ *
+ * `resolveModelMetadata()` 已经用 `resolutionSources.contextWindow === 'fallback'` 表达
+ * 「窗口未知」，这里只是把这个事实和实际生效的数值一起返回，供上层（含渲染层提示）消费。
+ */
+export function resolveEffectiveContextWindow(
+  metadata: Pick<ResolvedModelMetadata, 'contextWindowTokens' | 'resolutionSources'>,
+): EffectiveContextWindow {
+  const known = metadata.resolutionSources.contextWindow !== 'fallback'
+  if (known && typeof metadata.contextWindowTokens === 'number' && metadata.contextWindowTokens > 0) {
+    return { contextWindowTokens: metadata.contextWindowTokens, source: 'known' }
+  }
+  return { contextWindowTokens: FALLBACK_CONTEXT_WINDOW_TOKENS, source: 'fallback' }
+}
 
 // ============================================================================
 // 压缩参数推导

--- a/apps/electron/src/main/lib/token-usage-service.test.ts
+++ b/apps/electron/src/main/lib/token-usage-service.test.ts
@@ -52,6 +52,7 @@ describe('token usage service', () => {
       expect(second.totals.totalTokens).toBe(450)
       expect(second.models[0]?.modelId).toBe('gpt-4o')
       expect(second.models[0]?.requestCount).toBe(2)
+      expect(second.totals.cacheCoverageRate).toBeCloseTo(25 / 325)
       expect(existsSync(join(dir, 'token-usage-2026-05.jsonl'))).toBe(true)
     } finally {
       if (originalConfigDir === undefined) {

--- a/apps/electron/src/main/lib/token-usage-service.ts
+++ b/apps/electron/src/main/lib/token-usage-service.ts
@@ -105,6 +105,8 @@ function mergeIntoTotals(totals: TokenUsageTotals, record: TokenUsageRecord): vo
   totals.costUsd += record.costUsd
   const cacheTotal = totals.cacheReadTokens + totals.cacheCreationTokens
   totals.cacheHitRate = cacheTotal > 0 ? totals.cacheReadTokens / cacheTotal : 0
+  const contextTotal = totals.inputTokens + cacheTotal
+  totals.cacheCoverageRate = contextTotal > 0 ? totals.cacheReadTokens / contextTotal : 0
 }
 
 function normalizeTokenUsageKind(value: unknown): TokenUsageKind | undefined {

--- a/apps/electron/src/renderer/atoms/agent-context-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-context-atoms.ts
@@ -2,11 +2,12 @@ import { atom, type Atom } from 'jotai'
 import type {
   AgentMessage,
   AgentPendingFile,
+  ProviderDbModel,
   SessionMessage,
 } from '@kila/shared'
 import {
   estimateSessionContext,
-  inferContextWindow,
+  resolveModelMetadata,
   withLegacyAttachedFilesBlock,
 } from '@kila/shared'
 import type {
@@ -86,18 +87,28 @@ function serializeAgentMessageForEstimate(message: AgentMessage): SessionMessage
 }
 
 function resolveContextWindow(
+  channel: AgentContextChannelMeta | null | undefined,
   modelId: string | undefined,
   streamState?: AgentStreamState,
   calibration?: AgentContextCalibrationSnapshot,
+  providerDbEntry?: ProviderDbModel | null,
 ): number | undefined {
   if (streamState?.contextWindow) {
     return streamState.contextWindow
   }
 
-  // 静态估算与运行时 buildPiModel 同源：走模型名推断，不依赖 Provider DB / 内置目录。
-  // 手动覆盖无法在此感知（渲染层无该信息），由流式 usage_update 的真实窗口覆盖。
-  if (modelId) {
-    return inferContextWindow(modelId)
+  if (channel && modelId) {
+    const metadata = resolveModelMetadata({
+      channelProvider: channel.provider,
+      channelBaseUrl: channel.baseUrl,
+      modelId,
+      // 注入 Provider DB 命中：capabilityProviderId 常按协议配成 'openai'，静态估算时
+      // 若不传 entry，resolveModelMetadata 拿不到 DB 窗口，只能等流式 usage_update 回来才正确。
+      providerDbEntry: providerDbEntry ?? undefined,
+    })
+    if (metadata.contextWindowTokens) {
+      return metadata.contextWindowTokens
+    }
   }
 
   if (calibration?.modelId === modelId) {
@@ -111,13 +122,14 @@ export function deriveAgentContextStatus(
   input: AgentContextInput & {
     streamState?: AgentStreamState
     calibration?: AgentContextCalibrationSnapshot
+    providerDbEntry?: ProviderDbModel | null
   },
 ): AgentContextStatus {
   const modelId = input.modelId ?? input.streamState?.model
   const isCompacting = input.streamState?.isCompacting ?? false
   const hasLiveUsage = typeof input.streamState?.inputTokens === 'number' && input.streamState.inputTokens > 0
   const includeDraft = !input.streamState?.running && !hasLiveUsage
-  const contextWindow = resolveContextWindow(modelId ?? undefined, input.streamState, input.calibration)
+  const contextWindow = resolveContextWindow(input.channel, modelId ?? undefined, input.streamState, input.calibration, input.providerDbEntry)
 
   if (!modelId || (!hasLiveUsage && !hasMeaningfulContextPayload(input, includeDraft))) {
     return {
@@ -156,6 +168,33 @@ export const agentContextInputsAtom = atom<Map<string, AgentContextInput>>(new M
 export const agentContextCalibrationSnapshotsAtom = atom<Map<string, AgentContextCalibrationSnapshot>>(new Map())
 export const agentContextSnapshotsAtom = atom<Map<string, SessionContextSnapshot>>(new Map())
 
+/**
+ * Provider DB 模型 entry 缓存（按 modelId）。
+ *
+ * 渲染层静态估算 contextWindow 时需要 DB 的 limit.context。capabilityProviderId 常按协议
+ * 配成 'openai'，而模型实际归属另一个 provider，resolveModelMetadata 不传 entry 拿不到 DB 窗口。
+ * 这里通过 findProviderDbModel IPC 异步预取并缓存，agentContextStatusAtomFamily 同步读取。
+ * null 表示已查过但未命中，避免重复 IPC。
+ */
+export const providerDbModelCacheAtom = atom<Map<string, ProviderDbModel | null>>(new Map())
+
+/** 按 modelId 异步预取 Provider DB entry 并回填缓存；已缓存则跳过。 */
+export const prefetchProviderDbModelAtom = atom(null, async (get, set, modelId: string) => {
+  const cache = get(providerDbModelCacheAtom)
+  if (cache.has(modelId)) return
+  try {
+    const hit = await window.electronAPI.findProviderDbModel(modelId)
+    const next = new Map(cache)
+    next.set(modelId, hit?.model ?? null)
+    set(providerDbModelCacheAtom, next)
+  } catch {
+    // 查询失败也标记为已查，避免反复触发 IPC；静态估算会退到 provider rule / calibration。
+    const next = new Map(cache)
+    next.set(modelId, null)
+    set(providerDbModelCacheAtom, next)
+  }
+})
+
 const agentContextStatusAtomCache = new Map<string, Atom<AgentContextStatus>>()
 
 export function agentContextStatusAtomFamily(sessionId: string) {
@@ -167,7 +206,9 @@ export function agentContextStatusAtomFamily(sessionId: string) {
     const streamState = get(agentStreamingStatesAtom).get(sessionId)
     const calibration = get(agentContextCalibrationSnapshotsAtom).get(sessionId)
     const snapshot = get(agentContextSnapshotsAtom).get(sessionId)
+    const providerDbCache = get(providerDbModelCacheAtom)
     const modelId = input?.modelId ?? streamState?.model ?? snapshot?.modelId
+    const providerDbEntry = modelId ? providerDbCache.get(modelId) : undefined
 
     if (!input) {
       return {
@@ -203,6 +244,7 @@ export function agentContextStatusAtomFamily(sessionId: string) {
       ...input,
       streamState,
       calibration,
+      providerDbEntry,
     })
   })
   agentContextStatusAtomCache.set(sessionId, created)

--- a/apps/electron/src/renderer/components/composer/ContextUsageIndicator.tsx
+++ b/apps/electron/src/renderer/components/composer/ContextUsageIndicator.tsx
@@ -6,10 +6,11 @@
  * 避免流式更新时穿透 React.memo。
  */
 
+import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { useAtomValue } from 'jotai'
+import { useAtomValue, useSetAtom } from 'jotai'
 import { Gauge } from 'lucide-react'
-import { agentContextStatusAtomFamily } from '@/atoms/agent-context-atoms'
+import { agentContextStatusAtomFamily, prefetchProviderDbModelAtom } from '@/atoms/agent-context-atoms'
 import { formatTokenCount } from '@/atoms/usage-atoms'
 import { cn } from '@/lib/utils'
 import { ToolbarHoverPopover } from './ToolbarHoverPopover'
@@ -47,6 +48,15 @@ export function ContextUsageIndicator({
 }: ContextUsageIndicatorProps) {
   const { t } = useTranslation()
   const contextStatus = useAtomValue(agentContextStatusAtomFamily(sessionId))
+  const prefetchProviderDbModel = useSetAtom(prefetchProviderDbModelAtom)
+
+  // modelId 变化时异步预取 Provider DB entry，让静态估算（发消息前）也能拿到正确的 DB 窗口。
+  // 流式开始后 streamState.contextWindow 优先级最高，此时预取结果不再关键，但成本极低。
+  React.useEffect(() => {
+    if (contextStatus.modelId) {
+      void prefetchProviderDbModel(contextStatus.modelId)
+    }
+  }, [contextStatus.modelId, prefetchProviderDbModel])
 
   const hasData = typeof contextStatus.inputTokens === 'number' && contextStatus.inputTokens > 0
   const percent = hasData && contextStatus.contextWindow && contextStatus.inputTokens

--- a/apps/electron/src/renderer/components/composer/ModelSelector.tsx
+++ b/apps/electron/src/renderer/components/composer/ModelSelector.tsx
@@ -100,12 +100,10 @@ export function buildModelCapabilityChips(option: ModelOption): ModelCapabilityC
 
   const chips: ModelCapabilityChip[] = []
 
-  // context 窗口单一数据源：resolveModelMetadata 已按 手动覆盖 ?? 模型名推断 计算。
-  const contextWindow = metadata.contextWindowTokens
-  if (contextWindow) {
+  if (metadata.contextWindowTokens) {
     chips.push({
       key: 'context-window',
-      label: formatContextWindow(contextWindow),
+      label: formatContextWindow(metadata.contextWindowTokens),
     })
   }
   if (metadata.abilities.tools === 'supported') {

--- a/apps/electron/src/renderer/components/settings/TokenUsageSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/TokenUsageSettings.tsx
@@ -86,11 +86,13 @@ function getModelContextLabel(model: TokenUsageModelStat, t: TFunction): { label
   })
   return {
     label: formatTokenWindow(metadata.contextWindowTokens, t),
-    source: metadata.resolutionSources.contextWindow === 'manual'
-      ? t('settings.tokenUsage.sourceManual')
-      : metadata.resolutionSources.contextWindow === 'inference'
-        ? t('settings.tokenUsage.sourceInference')
-        : t('settings.tokenUsage.sourceDefault'),
+    source: metadata.resolutionSources.contextWindow === 'builtin'
+      ? t('settings.tokenUsage.sourceBuiltin')
+      : metadata.resolutionSources.contextWindow === 'provider-rule'
+        ? t('settings.tokenUsage.sourceRule')
+        : metadata.resolutionSources.contextWindow === 'manual'
+          ? t('settings.tokenUsage.sourceManual')
+          : t('settings.tokenUsage.sourceDefault'),
   }
 }
 
@@ -310,7 +312,7 @@ export function TokenUsageSettings(): React.ReactElement {
             <MetricCard
               label={t('settings.tokenUsage.cache')}
               value={formatInteger(getCacheTokens(stats.totals))}
-              description={`cache read + cache create · hit ${formatPercent(stats.totals.cacheHitRate)}`}
+              description={`cache read + cache create · hit ${formatPercent(stats.totals.cacheHitRate)} · coverage ${formatPercent(stats.totals.cacheCoverageRate)}`}
             />
             <MetricCard
               label={t('settings.tokenUsage.cost')}

--- a/apps/electron/src/renderer/locales/en/settings.json
+++ b/apps/electron/src/renderer/locales/en/settings.json
@@ -480,7 +480,6 @@
       "sourceBuiltinReference": "Built-in reference",
       "sourceRule": "Rule",
       "sourceManual": "User setting",
-      "sourceInference": "Inferred",
       "sourceDefault": "Default",
       "sourceUnset": "Not configured"
     },

--- a/apps/electron/src/renderer/locales/zh-CN/settings.json
+++ b/apps/electron/src/renderer/locales/zh-CN/settings.json
@@ -479,7 +479,6 @@
       "sourceBuiltinReference": "内置参考",
       "sourceRule": "规则",
       "sourceManual": "用户设置",
-      "sourceInference": "推断",
       "sourceDefault": "默认值",
       "sourceUnset": "未配置"
     },

--- a/docs/prompt-cache-optimization.md
+++ b/docs/prompt-cache-optimization.md
@@ -1,0 +1,31 @@
+# Prompt/KV Cache 优化
+
+Kila 的 Pi adapter 现在把请求分成稳定前缀和当前轮尾部：
+
+1. system prompt 不包含 session ID；MCP、Skills、工作目录等稳定运行时信息只作为带 fingerprint 的 snapshot 注入一次。
+2. 工具按 code-unit 名称排序，JSON Schema 对象 key 递归排序。
+3. 普通请求和 Pi compaction 请求使用同一个 Kila session ID 与显式 cache retention。
+4. compaction 不再把历史序列化成单段 `<conversation>` 冷启动消息，而是重放上一次真实 provider 请求的 system、tools 和选中消息前缀，最后追加 Pi 的摘要指令。
+
+## retention 配置
+
+模型兼容覆盖可以选择短缓存（默认）或长缓存：
+
+```json
+{
+  "id": "my-model",
+  "compat": {
+    "promptCacheRetention": "short"
+  }
+}
+```
+
+只有 provider 同时声明 `supportsLongCacheRetention: true` 时，`long` 才会映射为 provider 的长 TTL；否则 SDK 会安全降级为短缓存。长 TTL 适合跨较长空闲时间复用的会话，短缓存通常更省写入成本。
+
+## 命中率口径
+
+- `cacheHitRate = cacheRead / (cacheRead + cacheCreation)`：已写入缓存部分的复用率。
+- `cacheCoverageRate = cacheRead / (input + cacheRead + cacheCreation)`：本次输入总量中由缓存覆盖的比例。
+
+两者不能混用。即使 cache hit rate 接近 100%，新增长的用户消息、工具结果、provider 最小缓存粒度和 compaction 摘要指令仍可能让 coverage 低于 100%。实际结果取决于 provider 的 KV cache 规则；Kila 可以把稳定前缀做到接近 90%+，但不能对不支持 prompt caching 的 provider 保证 100%。
+

--- a/packages/shared/src/types/channel.ts
+++ b/packages/shared/src/types/channel.ts
@@ -199,6 +199,30 @@ export interface ModelMetadataOverride {
 }
 
 /**
+ * Provider 协议兼容覆盖（缓存相关子集）。
+ *
+ * 自定义 OpenAI-compatible/Anthropic-compatible 网关通常无法仅靠 URL 自动判断
+ * cache_control、session affinity 与长缓存能力，因此允许按模型显式透传给 Pi。
+ */
+export interface ModelCompatOverride {
+  /** OpenAI-compatible 接口是否使用 Anthropic 风格 cache_control 标记。 */
+  cacheControlFormat?: 'anthropic'
+  /** 是否发送 session-affinity headers。 */
+  sendSessionAffinityHeaders?: boolean
+  /** session-affinity header 格式。 */
+  sessionAffinityFormat?: 'openai' | 'openai-nosession' | 'openrouter'
+  /** provider 是否支持长时缓存保留。 */
+  supportsLongCacheRetention?: boolean
+  /** OpenAI Responses 模型是否支持显式 prompt cache mode。 */
+  supportsExplicitPromptCacheMode?: boolean
+  /**
+   * Kila 请求使用的 prompt cache 保留档位；默认 short。
+   * long 仅在 provider 同时声明 supportsLongCacheRetention 时产生长 TTL。
+   */
+  promptCacheRetention?: 'short' | 'long'
+}
+
+/**
  * 渠道中的模型配置
  */
 export interface ChannelModel {
@@ -210,6 +234,8 @@ export interface ChannelModel {
   enabled: boolean
   /** 手动覆盖模型元数据（可选，优先于内置目录和自动检测） */
   metadataOverride?: ModelMetadataOverride
+  /** 自定义 provider 的 prompt cache / session affinity 兼容覆盖。 */
+  compat?: ModelCompatOverride
   /** @deprecated 旧能力覆盖格式。读取时会迁移为 metadataOverride.abilities。 */
   capabilities?: ModelCapabilitiesOverride
 }

--- a/packages/shared/src/types/token-usage.ts
+++ b/packages/shared/src/types/token-usage.ts
@@ -32,6 +32,8 @@ export interface TokenUsageTotals {
   cacheCreationTokens: number
   totalTokens: number
   costUsd: number
+  /** cacheRead / (input + cacheRead + cacheCreation)，反映全部上下文 token 的实际复用率。 */
+  cacheCoverageRate?: number
   cacheHitRate?: number
 }
 

--- a/scripts/check-file-size.ts
+++ b/scripts/check-file-size.ts
@@ -63,7 +63,9 @@ async function collectFileStats(): Promise<FileStat[]> {
   for (const pattern of SCAN_GLOBS) {
     const glob = new Glob(pattern)
     for await (const match of glob.scan({ cwd: ROOT, absolute: true })) {
-      const relPath = relative(ROOT, match)
+      // Windows 上 relative() 返回反斜杠路径，而 baseline 键统一用正斜杠；
+      // 不规范化会导致 Windows 本地永远匹配不上 baseline，把存量文件全部误报为新增。
+      const relPath = relative(ROOT, match).replaceAll('\\', '/')
       if (shouldSkip(relPath) || seen.has(relPath)) continue
       seen.add(relPath)
 

--- a/scripts/file-size-baseline.json
+++ b/scripts/file-size-baseline.json
@@ -1,6 +1,6 @@
 {
   "apps/electron/src/main/lib/adapters/pi-agent-adapter.ts": {
-    "lines": 1247
+    "lines": 1402
   },
   "apps/electron/src/main/lib/im-bridge/adapters/feishu-adapter.ts": {
     "lines": 888


### PR DESCRIPTION
## 背景

长会话/压缩场景下 prompt 缓存命中率低，主要三个原因：
1. **per-message 动态上下文抖动**：每次请求把 MCP/Skills/项目目录等稳定配置全量重发，破坏 append-only 前缀；
2. **压缩是冷请求**：Pi 0.82 压缩时用 `cacheRetention: "none"` + 随机 session id，长会话压缩后热缓存全部失效；
3. **工具列表顺序不稳定**：工具注册顺序/JSON schema key 顺序随运行变化，导致同一前缀 hash 不稳定。

## 改动内容

### commit 1: 稳定 prompt 前缀
- `agent-prompt-builder`：拆出 `DynamicContextProjection`，per-message 只保留时钟信息，稳定配置（MCP/Skills/项目目录/会话 ID）作为 runtime snapshot 按需注入一次
- `pi-agent-adapter`：接通 `runtimeContext`/`runtimeContextFingerprint`，`compaction_end` 后强制刷新；`createRuntimeSignature` 对工具 schema 做 key 排序，签名稳定
- `pi-cache-aware-compaction`（新增）：压缩请求重放 system/tools/选中消息前缀，仅追加摘要指令，避免压缩变冷请求
- `agent-tool-names`：新增 `canonicalizeAgentTools`（工具名排序 + JSON key 排序）
- `channel`：新增 `ModelCompatOverride`（cacheControlFormat / sessionAffinity / promptCacheRetention），并按 provider（openrouter/cloudflare/fireworks/deepseek）自动推断
- `check-file-size`：修复 Windows 反斜杠路径与 baseline 不匹配（owner 环境为 Windows，本地一直被误报）

### commit 2: 保守窗口兜底 + 覆盖率指标
- `compaction-settings`：新增 `resolveEffectiveContextWindow`，未知模型窗口从 200K 收紧到保守 32K，避免小窗口模型/私有聚合商按 200K 预算压缩时直接撞 context overflow
- `token-usage`：新增 `cacheCoverageRate = cacheRead / (input + cacheRead + cacheCreate)`，更真实反映全量上下文缓存覆盖；TokenUsageSettings 展示 coverage 与窗口来源
- `agent-context-atoms`：前端窗口解析改走 `resolveModelMetadata` + Provider DB 预取缓存，解决 UI 显示窗口与运行时不一致
- `channel-manager`：模型刷新时保留 `metadataOverride`/`compat`，避免手动覆盖丢失

## 验证
- `bun run typecheck`：全部 5 个 workspace 通过
- 相关单测：54 个 pass（canonicalize 稳定性、cache-aware compaction projection、cacheCoverageRate、runtime snapshot 指纹稳定等）
- lint（biome）+ file-size 闸门通过
- pre-push 钩子 typecheck 通过；全量 bun test 中与本改动相关的用例全部通过（14 个失败均为 Windows 本地环境限制：symlink 权限 / git worktree / ESM loader，CI 在 Linux 上不受影响）

## 备注
- `pi-model-catalog.ts` 保留未删（当前窗口解析统一走 `resolveEffectiveContextWindow`，该文件暂留供后续复用）
